### PR TITLE
feat/fix: project/team/edit page improvements

### DIFF
--- a/models/teamdb.py
+++ b/models/teamdb.py
@@ -3,6 +3,7 @@ from time import time
 from typing import Any, Optional
 
 from pymongo.collection import ReturnDocument
+from pymongo.results import DeleteResult
 
 from models.base import DBBase
 
@@ -91,6 +92,16 @@ class TeamDB(DBBase):
             {'$set': data},
             upsert=True,
             return_document=ReturnDocument.AFTER,
+        )
+
+    def delete(self) -> DeleteResult:
+        ''' Delete this team from database
+
+        Returns:
+            Return ``DeleteResult``.
+        '''
+        return self.delete_one(
+            {'pid': self.pid, 'tid': self.tid},
         )
 
     def update_setting(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/module/team.py
+++ b/module/team.py
@@ -32,6 +32,21 @@ class Team:
         return teamdb.add(data)
 
     @staticmethod
+    def delete(pid: str, tid: str) -> bool:
+        ''' Delete the specified team from database
+
+        :param str pid: project id
+        :param str tid: team id
+        '''
+        if not tid or not pid:
+            raise Exception('lost required')
+
+        teamdb = TeamDB(pid, tid)
+        result = teamdb.delete()
+
+        return result.deleted_count == 1
+
+    @staticmethod
     def update_chiefs(pid: str, tid: str,
                       add_uids: Optional[list[str]] = None,
                       del_uids: Optional[list[str]] = None) -> None:

--- a/templates/project_edit_create_team.html
+++ b/templates/project_edit_create_team.html
@@ -8,7 +8,13 @@
             <ul>
             {% for team in teams %}
             <li>
-                {{team.name}} ({{team.tid}}) <a v-on:click="showedit('{{team.tid}}', '{{team.name}}')"><span class="icon"><i class="far fa-edit"></i></span><span>編輯</span></a>
+                {{team.name}} ({{team.tid}})
+                <a v-on:click="showedit('{{team.tid}}', '{{team.name}}')">
+                    <span class="icon"><i class="far fa-edit"></i></span><span>編輯</span>
+                </a>
+                <a v-on:click="showdelete('{{team.tid}}', '{{team.name}}')">
+                    <span class="icon"><i class="far fa-trash-alt"></i></span><span>刪除</span>
+                </a>
             </li>
             {% endfor %}
             <li><a v-on:click="showcreate()"><span class="icon"><i class="far fa-plus-square"></i></span><span>建立</span></a></li>
@@ -109,6 +115,18 @@
                         $project.modalBody.submittype = 'update';
                         $project.fixpage();
                     });
+                },
+                showdelete: function (tid, name) {
+                    const shouldDelete = confirm(`要從資料庫移除 ${name} (${tid}) 嗎？`);
+                    if (!shouldDelete) return;
+
+                    return axios.delete('./team/api', { params: { tid }})
+                        .then((response) => {
+                            location.reload();
+                        })
+                        .catch(() => {
+                            alert(`無法刪除 TID ${tid}。`);
+                        });
                 },
                 showcreate: function() {
                     this.modalTitle = '建立新的組別';

--- a/templates/project_edit_create_team.html
+++ b/templates/project_edit_create_team.html
@@ -27,14 +27,14 @@
                         <div class="control">
                             <input class="input" type="text" name="name" v-model="modalBody.name">
                         </div>
-                        <p class="help is-success">組別名稱</p>
+                        <p class="help is-success">組別名稱。<b>必填。</b></p>
                     </div>
                     <div class="field">
                         <label class="label">tid</label>
                         <div class="control">
                             <input class="input" type="text" name="tid" v-model="modalBody.tid" v-bind:readonly="modalBody.submittype === 'update'">
                         </div>
-                        <p class="help is-success">組別 id，皆用英文表示</p>
+                        <p class="help is-success">組別 id，皆用英文表示。<b>必填。</b></p>
                     </div>
                     <div class="field">
                         <label class="label">headcount</label>
@@ -118,10 +118,19 @@
                 },
                 gosubmit: function(btn) {
                     btn.target.classList.add('is-loading');
+
                     axios.post('./team/api', this.modalBody).then(function(resp){
                         $project.goback();
                         window.location.href = './team';
-                    });
+                    }).catch(function (error) {
+                        const statusCode = error.response?.status;
+
+                        if (statusCode && statusCode >= 500) {
+                            alert('資料有誤，請檢查資料是否正確。另外 name 和 tid 必須填寫。');
+                        } else {
+                            alert(`請求失敗。伺服器回傳 HTTP ${statusCode} 錯誤。`);
+                        }
+                    }).finally(() => btn.target.classList.remove('is-loading'));
                 },
                 fixpage: function() {
                     this.isActive = true;

--- a/view/project.py
+++ b/view/project.py
@@ -332,7 +332,7 @@ def project_form_api(pid):
     return jsonify({}), 404
 
 
-@VIEW_PROJECT.route('/<pid>/edit/team/api', methods=('GET', 'POST'))
+@VIEW_PROJECT.route('/<pid>/edit/team/api', methods=('GET', 'POST', 'DELETE'))
 def project_edit_create_team_api(pid):
     ''' Project edit create team API '''
     project = Project.get(pid)
@@ -385,6 +385,16 @@ def project_edit_create_team_api(pid):
             Team.create(
                 pid=pid, tid=data['tid'], name=data['name'], owners=project['owners'])
             return f'{data}'
+
+    if request.method == 'DELETE':
+        tid = request.args.get('tid')
+
+        if not tid:
+            return 'missing “tid” in request payload', 400
+
+        result = Team.delete(pid, tid)
+
+        return ('ok', 200) if result else ('delete failed', 500)
 
     return '', 404
 


### PR DESCRIPTION
## emphasize 'name' & 'tid' are required

目前 “name” 或 “tid” 任一沒填，直接按下 Save，伺服器會回傳 500 錯誤，而 UI 會卡在無限轉圈圈。

這個 commit 加上了更明確的提醒；且如果以上任一未填寫，會跳出 `alert` 提醒使用者。
同時請求結束後，轉圈動效亦會自動結束（`finally`）。

![SCR-20220712-scy](https://user-images.githubusercontent.com/28441561/178505771-49288ddb-f0d4-4f1c-895a-1e6bb2a1a145.png)

## allow deleting team

目前 projects 的 team 是不能在 UI 端刪除的。本 commit 加入了相關的功能。

![SCR-20220712-ubk](https://user-images.githubusercontent.com/28441561/178505875-d3e62c9e-b882-4b30-9aa6-a362655f489f.png)

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
<!-- 是否是相關的已知 Issues -->

- 目前 “name” 或 “tid” 任一沒填，直接按下 Save，伺服器會回傳 500 錯誤，而 UI 會卡在無限轉圈圈。
- 目前 projects 的 team 是不能在 UI 端刪除的。

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 現在新增 team，若忘記填寫 “name” 或 “tid”，會跳出「資料有誤」提醒。
- 現在可以透過「編輯」旁的「刪除」連結，刪除不想要的 team。

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->