### PR TITLE
#113 filter expense by status

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,10 +42,8 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-      - name: Check packages
-        run: poetry update -v --dry-run
       - name: Install dependencies
-        run: poetry update -v
+        run: poetry install -v
       - name: Show packages
         run: poetry show --tree
       - name: Create setting.py

--- a/Dockerfile-app-dev
+++ b/Dockerfile-app-dev
@@ -85,6 +85,9 @@ ADD ./templates/base.html \
     ./templates/user.html \
     ./templates/
 
+ADD ./static/ExpenseStatusLabel.js \
+    ./static/
+
 ADD ./templates/mail/base*.html \
     ./templates/mail/coscup_base.html \
     ./templates/mail/sender_base.html \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       - $PWD/module:/app/module
       - $PWD/templates:/app/templates
       - $PWD/view:/app/view
+      - $PWD/static:/app/static
       - $PWD/structs:/app/structs
     depends_on:
       - memcached-prod

--- a/static/ExpenseStatusLabel.js
+++ b/static/ExpenseStatusLabel.js
@@ -1,7 +1,7 @@
 (function () {
     const tpl = `
-        <div :class="labelClass" :role="role">
-            <span class="icon"><i :class="iconClass"></i></span>
+        <div :class="labelClass" :role="role" @click="$emit('click')">
+            <span v-if="showIcon" class="icon"><i :class="iconClass"></i></span>
             <span>{{ labelMeta.label }}</span>
         </div>`
     const statusMetaMap = {
@@ -18,13 +18,23 @@
     }
     Vue.component('expense-status-label', {
       props: {
+        statusCode: {
+            type: Number,
+            default: 0
+        },
         item: {
             type: Object,
-            required: true
+            validator (item) {
+                return 'status' in item
+            }
         },
         role: {
             type: String,
             default: ''
+        },
+        showIcon: {
+            type: Boolean,
+            default: true
         }
       },
       computed: {
@@ -35,7 +45,7 @@
             return ['fas', `fa-${this.labelMeta.icon}`]
         },
         labelMeta () {
-            const statusCode = this.item.status
+            const statusCode = this.statusCode || this.item.status
             if (statusCode in statusMetaMap) {
                 return statusMetaMap[statusCode]
             } else if (!this.item.enable) {

--- a/static/ExpenseStatusLabel.js
+++ b/static/ExpenseStatusLabel.js
@@ -1,0 +1,50 @@
+(function () {
+    const tpl = `
+        <div :class="labelClass" :role="role">
+            <span class="icon"><i :class="iconClass"></i></span>
+            <span>{{ labelMeta.label }}</span>
+        </div>`
+    const statusMetaMap = {
+        // as this is the only place to define color & icon for each status code
+        // there's no way to migrate it back to expense model or module
+        // as the result, no need to pass status from expense view :p
+        1: { color: 'is-warning', icon: 'hand-paper', label: '已申請' },
+        2: { color: 'is-link', icon: 'bolt', label: '審核中' },
+        3: { color: 'is-primary', icon: 'hand-holding-usd', label: '出款中' },
+        4: { color: 'is-success', icon: 'stamp', label: '已出款' },
+        5: { color: 'is-success', icon: 'clipboard-check', label: '已完成' },
+        disable: { color: 'is-danger', icon: 'ban', label: '已刪除' },
+        unknown: { color: 'is-danger', icon: 'ban', label: '不明狀態' }
+    }
+    Vue.component('expense-status-label', {
+      props: {
+        item: {
+            type: Object,
+            required: true
+        },
+        role: {
+            type: String,
+            default: ''
+        }
+      },
+      computed: {
+        labelClass () {
+            return [this.labelMeta.color]
+        },
+        iconClass () {
+            return ['fas', `fa-${this.labelMeta.icon}`]
+        },
+        labelMeta () {
+            const statusCode = this.item.status
+            if (statusCode in statusMetaMap) {
+                return statusMetaMap[statusCode]
+            } else if (!this.item.enable) {
+                return statusMetaMap.disable
+            }
+            // always return sth, so we know sth goes wrong
+            return statusMetaMap.unknown
+        }
+      },
+      template: tpl
+    })
+})()

--- a/templates/expense.html
+++ b/templates/expense.html
@@ -5,6 +5,11 @@
     .is-delete {
       text-decoration: line-through;
     }
+    .button.is-filter {
+        background: white;
+        border-color: #888;
+        color: #888;
+    }
 </style>
 {% endblock %}
 {% block body %}
@@ -20,6 +25,16 @@
   <div id="expense" class="container" v-cloak>
       <div class="columns">
           <div class="column">
+            <div class="buttons">
+                <expense-status-label
+                    v-for="status in statusList"
+                    :key="status.code"
+                    role="button"
+                    :class="get_status_filter_class(status)"
+                    :status-code="status.code"
+                    @click="filter_by_status(status)"
+                ></expense-status-label>
+            </div>
           </div>
           <div class="column">
               <div class="field is-grouped is-grouped-right">
@@ -56,20 +71,28 @@
                   </tr>
               </thead>
               <tbody>
-                  <tr v-if="items.length == 0">
-                      <td colspan="8" class="has-text-centered">
-                          <span class="icon"><i class="fas fa-info-circle"></i></span>
-                          <span>目前沒有項目</span>
+                  <tr v-if="visibleItems.length == 0">
+                      <td colspan="9" class="has-text-centered">
+                          <div class="message is-warning">
+                            <div class="message-body">
+                                <div class="is-flex is-align-items-center">
+                                    <span class="icon"><i class="fas fa-info-circle"></i></span>
+                                    目前沒有
+                                    <expense-status-label :show-icon="false" :status-code="filter.statusCode" class="is-inline"></expense-status-label>
+                                    的項目
+                                </div>
+                            </div>
+                          </div>
                       </td>
                   </tr>
-                  <tr v-for="item, index in items" :class="{'is-delete': item.enabled === false}">
+                  <tr v-for="item, index in visibleItems" :class="{'is-delete': item.enabled === false}">
                       <td class="is-vcentered">
                           <p><span class="tag is-link is-light">[[ item.code ]]</span></p>
 
                           <p class="is-size-7">[[ new Date(item.create_at).toLocaleString() ]]</p>
                       </td>
                       <td class="is-vcentered">
-                          <expense-status-label class="tag is-clickable" @click.native="edit(item, index)" :item="item"></expense-status-label>
+                          <expense-status-label class="tag is-clickable" @click="edit(item, index)" :item="item"></expense-status-label>
                       </td>
                       <td class="is-vcentered">
                           <span class="tag is-dark">[[ budgets[item.request.buid].bid ]]</span>
@@ -278,17 +301,22 @@
     (function () {
         let $expense = new Vue({
             el: '#expense',
-            data: {
-                pid: '{{ project._id }}',
-                teams: [],
-                modaldata: {show: false},
-                default_modaldata: {show: false, is_loading: 0},
+            data () {
+                return {
+                    pid: '{{ project._id }}',
+                    teams: [],
+                    modaldata: {show: false},
+                    default_modaldata: {show: false, is_loading: 0},
 
-                items: [],
-                budgets: {},
-                users: {},
-                status: {},
-                is_loading: 0
+                    items: [],
+                    budgets: {},
+                    users: {},
+                    status: {},
+                    is_loading: 0,
+                    filter: {
+                        statusCode: '1'
+                    }
+                }
             },
             mounted: function() {
                 this.load();
@@ -301,9 +329,22 @@
                             return { code, label }
                         })
                         .sort((a, b) => a.code - b.code)
+                },
+                visibleItems () {
+                    return this.items.filter(item => item.status === this.filter.statusCode)
                 }
             },
             methods: {
+                get_status_filter_class (status) {
+                    const ret = ['button', 'is-filter']
+                    if (this.filter.statusCode === status.code) {
+                        ret.push('is-active')
+                    }
+                    return ret
+                },
+                filter_by_status (status) {
+                    this.filter.statusCode = status.code
+                },
                 create_budget: function() {
                     this.modaldata.show = true;
                     document.querySelector('html').classList.toggle('is-clipped');
@@ -325,16 +366,16 @@
                     this.modaldata = Object.assign({}, item, {is_edit: true, _index: index});
                     this.create_budget();
                 },
-                load: function() {
+                async load () {
                     ++this.is_loading;
-                    axios.post('./'+this.pid, {casename: 'get'}).then(function(resp) {
-                        $expense.items = resp.data.datas;
-                        $expense.budgets = resp.data.budgets;
-                        $expense.users = resp.data.users;
-                        $expense.status = resp.data.status;
+                    const resp = await axios.post('./'+this.pid, {casename: 'get'})
 
-                        --$expense.is_loading;
-                    });
+                    this.items = resp.data.datas;
+                    this.budgets = resp.data.budgets;
+                    this.users = resp.data.users;
+                    this.status = resp.data.status;
+
+                    --this.is_loading;
                 }
             },
             delimiters: ['[[', ']]']

--- a/templates/expense.html
+++ b/templates/expense.html
@@ -190,9 +190,8 @@
                           <h4>請款狀態</h4>
                           <div class="select">
                               <select v-model="modaldata.status">
-                                  <option :value="val"
-                               v-for="[val, name] in Object.entries(status).sort(function(a,b){if(a[0]>b[0]){return 1;} return -1;})">
-                               [[ name ]]
+                                  <option v-for="status in statusList" :key="status.code" :value="status.code">
+                               [[ status.label ]]
                                   </option>
                               </select>
                           </div>
@@ -293,6 +292,16 @@
             },
             mounted: function() {
                 this.load();
+            },
+            computed: {
+                statusList () {
+                    return Object
+                        .entries(this.status)
+                        .map(([code, label]) => {
+                            return { code, label }
+                        })
+                        .sort((a, b) => a.code - b.code)
+                }
             },
             methods: {
                 create_budget: function() {

--- a/templates/expense.html
+++ b/templates/expense.html
@@ -18,8 +18,10 @@
 </section>
 <section class="section">
   <div id="expense" class="container" v-cloak>
-      <div class="column">
-          <div class="content">
+      <div class="columns">
+          <div class="column">
+          </div>
+          <div class="column">
               <div class="field is-grouped is-grouped-right">
                   <div class="buttons">
                       <button class="button is-loading" v-if="is_loading > 0"></button>
@@ -63,33 +65,11 @@
                   <tr v-for="item, index in items" :class="{'is-delete': item.enabled === false}">
                       <td class="is-vcentered">
                           <p><span class="tag is-link is-light">[[ item.code ]]</span></p>
+
                           <p class="is-size-7">[[ new Date(item.create_at).toLocaleString() ]]</p>
                       </td>
                       <td class="is-vcentered">
-                          <span class="tag is-warning is-clickable" @click="edit(item, index)" v-if="item.status == '1'">
-                              <span class="icon"><i class="far fa-hand-paper"></i></span>
-                              <span>[[ status[item.status] ]]</span>
-                          </span>
-                          <span class="tag is-link is-clickable" @click="edit(item, index)" v-if="item.status == '2'">
-                              <span class="icon"><i class="fas fa-bolt"></i></span>
-                              <span>[[ status[item.status] ]]</span>
-                          </span>
-                          <span class="tag is-primary is-clickable" @click="edit(item, index)" v-if="item.status == '3'">
-                              <span class="icon"><i class="fas fa-hand-holding-usd"></i></span>
-                              <span>[[ status[item.status] ]]</span>
-                          </span>
-                          <span class="tag is-success is-light is-clickable" @click="edit(item, index)" v-if="item.status == '4'">
-                              <span class="icon"><i class="fas fa-stamp"></i></span>
-                              <span>[[ status[item.status] ]]</span>
-                          </span>
-                          <span class="tag is-success is-clickable" @click="edit(item, index)" v-if="item.status == '5'">
-                              <span class="icon"><i class="fas fa-clipboard-check"></i></span>
-                              <span>[[ status[item.status] ]]</span>
-                          </span>
-                          <span class="tag is-danger is-clickable" @click="edit(item, index)" v-if="!item.enable">
-                              <span class="icon"><i class="fas fa-ban"></i></span>
-                              <span>已刪除</span>
-                          </span>
+                          <expense-status-label class="tag is-clickable" @click.native="edit(item, index)" :item="item"></expense-status-label>
                       </td>
                       <td class="is-vcentered">
                           <span class="tag is-dark">[[ budgets[item.request.buid].bid ]]</span>
@@ -294,6 +274,7 @@
 {% endblock %}
 {% block js %}
 <script src="/js/axios.min.js"></script>
+<script src="{{ url_for('static', filename='ExpenseStatusLabel.js') }}"></script>
 <script>
     (function () {
         let $expense = new Vue({


### PR DESCRIPTION
## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



Issue Number: #113

## What is the new behavior?

1. Implement #113 
2. Add `/static` directory, so to create shared vue component
   1. @toomore , please help to review this. I just verify this under local dev env.
1. Now we support limited vue component feature!
    - As there's no webpack or vue-loader, plain JS file is used.
    - i.e. No `<tpl>` tag, please apply HTML in plain text.




## Other information

1. Default show `申請中` expense
   > ![螢幕快照 2023-04-23 23-27-44](https://user-images.githubusercontent.com/271157/233849091-96b8fae1-0aa2-4bb0-8f67-4b166e79ada7.png)
2. Show `目前沒有<status label>的項目 ` when no expense item under this status
   >  ![螢幕快照 2023-04-23 23-27-42](https://user-images.githubusercontent.com/271157/233849094-8c997ba0-f6d2-47dc-91bd-ef03ca36990a.png)
